### PR TITLE
Update graalvm-ce to Version 21.0.0

### DIFF
--- a/.github/workflows/build-and-push-docker-builders.yml
+++ b/.github/workflows/build-and-push-docker-builders.yml
@@ -15,7 +15,7 @@ jobs:
           ref: ${{ github.event.inputs.ref }}
       - name: Build and Push Docker Images to Bintray
         shell: bash
-        run: ./distributions/scripts/build-and-push-docker-builders-to-bintray.sh
+        run: ./distributions/scripts/build-and-push-docker-builders.sh
         env:
           BINTRAY_USERNAME: ${{ secrets.BINTRAY_USERNAME }}
           BINTRAY_API_KEY: ${{ secrets.BINTRAY_API_KEY }}

--- a/.github/workflows/maven-ci.yml
+++ b/.github/workflows/maven-ci.yml
@@ -140,7 +140,7 @@ jobs:
       - name: Setup GraalVM
         uses: DeLaGuardo/setup-graalvm@master
         with:
-          graalvm-version: 20.3.0.java8
+          graalvm-version: 21.0.0.java8
       - name: Setup GraalVM Native Image Tool
         run: gu install native-image
       - name: Build Mac Native Image
@@ -182,18 +182,18 @@ jobs:
         run: ren *.jar native-image.jar
       - name: Setup GraalVM Native Image and Visual C Build Tools
         run: |
-          Invoke-RestMethod -Uri https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-20.3.0/graalvm-ce-java11-windows-amd64-20.3.0.zip -OutFile 'graal.zip'
+          Invoke-RestMethod -Uri https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.0.0/graalvm-ce-java11-windows-amd64-21.0.0.zip -OutFile 'graal.zip'
           Expand-Archive -path 'graal.zip' -destinationpath '.'
-          graalvm-ce-java11-20.3.0\bin\gu.cmd install native-image
+          graalvm-ce-java11-21.0.0\bin\gu.cmd install native-image
           choco install visualstudio2017-workload-vctools
       - name: Build Windows Native Image
         if: success()
         shell: cmd
         run: |
           call "C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
-          graalvm-ce-java11-20.3.0\bin\native-image -cp .\build\native-image.jar -H:+ReportExceptionStackTraces --report-unsupported-elements-at-runtime
+          graalvm-ce-java11-21.0.0\bin\native-image -cp .\build\native-image.jar -H:+ReportExceptionStackTraces --report-unsupported-elements-at-runtime
         env:
-          JAVA_HOME: ./graalvm-ce-java11-20.3.0
+          JAVA_HOME: ./graalvm-ce-java11-21.0.0
       - name: Archive Windows Native Image
         if: success()
         continue-on-error: true
@@ -201,6 +201,7 @@ jobs:
         with:
           name: windows-native-image
           path: sourcehawk.exe
+          JAVA_HOME: ./graalvm-ce-java11-21.0.0
       - name: Smoke Test
         if: success()
         shell: cmd

--- a/.github/workflows/maven-ci.yml
+++ b/.github/workflows/maven-ci.yml
@@ -140,7 +140,7 @@ jobs:
       - name: Setup GraalVM
         uses: DeLaGuardo/setup-graalvm@master
         with:
-          graalvm-version: 21.0.0.java8
+          graalvm-version: 21.1.0.java8
       - name: Setup GraalVM Native Image Tool
         run: gu install native-image
       - name: Build Mac Native Image
@@ -182,18 +182,18 @@ jobs:
         run: ren *.jar native-image.jar
       - name: Setup GraalVM Native Image and Visual C Build Tools
         run: |
-          Invoke-RestMethod -Uri https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.0.0/graalvm-ce-java11-windows-amd64-21.0.0.zip -OutFile 'graal.zip'
+          Invoke-RestMethod -Uri https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.1.0/graalvm-ce-java11-windows-amd64-21.1.0.zip -OutFile 'graal.zip'
           Expand-Archive -path 'graal.zip' -destinationpath '.'
-          graalvm-ce-java11-21.0.0\bin\gu.cmd install native-image
+          graalvm-ce-java11-21.1.0\bin\gu.cmd install native-image
           choco install visualstudio2017-workload-vctools
       - name: Build Windows Native Image
         if: success()
         shell: cmd
         run: |
           call "C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
-          graalvm-ce-java11-21.0.0\bin\native-image -cp .\build\native-image.jar -H:+ReportExceptionStackTraces --report-unsupported-elements-at-runtime
+          graalvm-ce-java11-21.1.0\bin\native-image -cp .\build\native-image.jar -H:+ReportExceptionStackTraces --report-unsupported-elements-at-runtime
         env:
-          JAVA_HOME: ./graalvm-ce-java11-21.0.0
+          JAVA_HOME: ./graalvm-ce-java11-21.1.0
       - name: Archive Windows Native Image
         if: success()
         continue-on-error: true
@@ -201,7 +201,7 @@ jobs:
         with:
           name: windows-native-image
           path: sourcehawk.exe
-          JAVA_HOME: ./graalvm-ce-java11-21.0.0
+          JAVA_HOME: ./graalvm-ce-java11-21.1.0
       - name: Smoke Test
         if: success()
         shell: cmd

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,7 +228,7 @@ jobs:
       - name: Setup GraalVM
         uses: DeLaGuardo/setup-graalvm@master
         with:
-          graalvm-version: 20.3.0.java8
+          graalvm-version: 21.0.0.java8
       - name: Setup GraalVM Native Image Tool
         run: gu install native-image
       - name: Build Mac Native Image
@@ -291,18 +291,18 @@ jobs:
         run: ren *.jar native-image.jar
       - name: Setup GraalVM Native Image and Visual C Build Tools
         run: |
-          Invoke-RestMethod -Uri https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-20.3.0/graalvm-ce-java11-windows-amd64-20.3.0.zip -OutFile 'graal.zip'
+          Invoke-RestMethod -Uri https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.0.0/graalvm-ce-java11-windows-amd64-21.0.0.zip -OutFile 'graal.zip'
           Expand-Archive -path 'graal.zip' -destinationpath '.'
-          graalvm-ce-java11-20.3.0\bin\gu.cmd install native-image
+          graalvm-ce-java11-21.0.0\bin\gu.cmd install native-image
           choco install visualstudio2017-workload-vctools
       - name: Build Windows Native Image
         if: success()
         shell: cmd
         run: |
           call "C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
-          graalvm-ce-java11-20.3.0\bin\native-image -cp .\build\native-image.jar -H:+ReportExceptionStackTraces --report-unsupported-elements-at-runtime
+          graalvm-ce-java11-21.0.0\bin\native-image -cp .\build\native-image.jar -H:+ReportExceptionStackTraces --report-unsupported-elements-at-runtime
         env:
-          JAVA_HOME: ./graalvm-ce-java11-20.3.0
+          JAVA_HOME: ./graalvm-ce-java11-21.0.0
       - name: Smoke Test
         if: success()
         shell: cmd

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,7 +228,7 @@ jobs:
       - name: Setup GraalVM
         uses: DeLaGuardo/setup-graalvm@master
         with:
-          graalvm-version: 21.0.0.java8
+          graalvm-version: 21.1.0.java8
       - name: Setup GraalVM Native Image Tool
         run: gu install native-image
       - name: Build Mac Native Image
@@ -291,18 +291,18 @@ jobs:
         run: ren *.jar native-image.jar
       - name: Setup GraalVM Native Image and Visual C Build Tools
         run: |
-          Invoke-RestMethod -Uri https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.0.0/graalvm-ce-java11-windows-amd64-21.0.0.zip -OutFile 'graal.zip'
+          Invoke-RestMethod -Uri https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.1.0/graalvm-ce-java11-windows-amd64-21.1.0.zip -OutFile 'graal.zip'
           Expand-Archive -path 'graal.zip' -destinationpath '.'
-          graalvm-ce-java11-21.0.0\bin\gu.cmd install native-image
+          graalvm-ce-java11-21.1.0\bin\gu.cmd install native-image
           choco install visualstudio2017-workload-vctools
       - name: Build Windows Native Image
         if: success()
         shell: cmd
         run: |
           call "C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
-          graalvm-ce-java11-21.0.0\bin\native-image -cp .\build\native-image.jar -H:+ReportExceptionStackTraces --report-unsupported-elements-at-runtime
+          graalvm-ce-java11-21.1.0\bin\native-image -cp .\build\native-image.jar -H:+ReportExceptionStackTraces --report-unsupported-elements-at-runtime
         env:
-          JAVA_HOME: ./graalvm-ce-java11-21.0.0
+          JAVA_HOME: ./graalvm-ce-java11-21.1.0
       - name: Smoke Test
         if: success()
         shell: cmd

--- a/distributions/docker-builders/Dockerfile-nativeimage
+++ b/distributions/docker-builders/Dockerfile-nativeimage
@@ -1,5 +1,5 @@
 # Oracle GraalVM Java 8 Base Container
-ARG FROM=oracle/graalvm-ce:20.3.0-java8
+ARG FROM=oracle/graalvm-ce:21.0.0-java8
 FROM ${FROM}
 
 # Install native-image tool

--- a/distributions/docker-builders/Dockerfile-nativeimage
+++ b/distributions/docker-builders/Dockerfile-nativeimage
@@ -1,5 +1,5 @@
 # Oracle GraalVM Java Base Container
-ARG FROM=ghcr.io/graalvm/graalvm-ce:21.0.0-java8
+ARG FROM=ghcr.io/graalvm/graalvm-ce:java8-21.0.0
 FROM ${FROM}
 
 # Install native-image tool

--- a/distributions/docker-builders/Dockerfile-nativeimage
+++ b/distributions/docker-builders/Dockerfile-nativeimage
@@ -1,5 +1,5 @@
 # Oracle GraalVM Java Base Container
-ARG FROM=ghcr.io/graalvm/graalvm-ce:java8-21.0.0
+ARG FROM=ghcr.io/graalvm/graalvm-ce:java8-21.1.0
 FROM ${FROM}
 
 # Install native-image tool

--- a/distributions/docker-builders/Dockerfile-nativeimage
+++ b/distributions/docker-builders/Dockerfile-nativeimage
@@ -1,5 +1,5 @@
-# Oracle GraalVM Java 8 Base Container
-ARG FROM=oracle/graalvm-ce:21.0.0-java8
+# Oracle GraalVM Java Base Container
+ARG FROM=ghcr.io/graalvm/graalvm-ce:21.0.0-java8
 FROM ${FROM}
 
 # Install native-image tool

--- a/distributions/linux/native-image-builder/Dockerfile
+++ b/distributions/linux/native-image-builder/Dockerfile
@@ -1,4 +1,4 @@
-ARG GRAALVM_VERSION=21.0.0-java8
+ARG GRAALVM_VERSION=21.1.0-java8
 FROM optum-docker-builders.bintray.io/nativeimage:graalvm-ce-${GRAALVM_VERSION}
 
 # Build Arguments

--- a/distributions/linux/native-image-builder/Dockerfile
+++ b/distributions/linux/native-image-builder/Dockerfile
@@ -1,4 +1,4 @@
-ARG GRAALVM_VERSION=20.3.0-java8
+ARG GRAALVM_VERSION=21.0.0-java8
 FROM optum-docker-builders.bintray.io/nativeimage:graalvm-ce-${GRAALVM_VERSION}
 
 # Build Arguments

--- a/distributions/linux/pom.xml
+++ b/distributions/linux/pom.xml
@@ -236,7 +236,7 @@
                 <jdk>8</jdk>
             </activation>
             <properties>
-                <graalvm.version>21.0.0-java8</graalvm.version>
+                <graalvm.version>21.1.0-java8</graalvm.version>
             </properties>
         </profile>
 
@@ -247,7 +247,7 @@
                 <jdk>11</jdk>
             </activation>
             <properties>
-                <graalvm.version>21.0.0-java11</graalvm.version>
+                <graalvm.version>21.1.0-java11</graalvm.version>
             </properties>
         </profile>
 

--- a/distributions/linux/pom.xml
+++ b/distributions/linux/pom.xml
@@ -236,7 +236,7 @@
                 <jdk>8</jdk>
             </activation>
             <properties>
-                <graalvm.version>20.3.0-java8</graalvm.version>
+                <graalvm.version>21.0.0-java8</graalvm.version>
             </properties>
         </profile>
 
@@ -247,7 +247,7 @@
                 <jdk>11</jdk>
             </activation>
             <properties>
-                <graalvm.version>20.3.0-java11</graalvm.version>
+                <graalvm.version>21.0.0-java11</graalvm.version>
             </properties>
         </profile>
 

--- a/distributions/scripts/build-and-push-docker-builders-to-bintray.sh
+++ b/distributions/scripts/build-and-push-docker-builders-to-bintray.sh
@@ -18,8 +18,8 @@ BINTRAY_REPO="builders"
 REGISTRY="optum-docker-builders.bintray.io"
 
 # Native Image
-docker build -t $REGISTRY/nativeimage:graalvm-ce-21.0.0-java8 -f "$DOCKER_BUILDERS_DIR/Dockerfile-nativeimage" --build-arg FROM=ghcr.io/graalvm/graalvm-ce:java8-21.0.0 .
-docker build -t $REGISTRY/nativeimage:graalvm-ce-21.0.0-java11 -f "$DOCKER_BUILDERS_DIR/Dockerfile-nativeimage" --build-arg FROM=ghcr.io/graalvm/graalvm-ce:java11-21.0.0 .
+docker build -t $REGISTRY/nativeimage:graalvm-ce-21.1.0-java8 -f "$DOCKER_BUILDERS_DIR/Dockerfile-nativeimage" --build-arg FROM=ghcr.io/graalvm/graalvm-ce:java8-21.1.0 .
+docker build -t $REGISTRY/nativeimage:graalvm-ce-21.1.0-java11 -f "$DOCKER_BUILDERS_DIR/Dockerfile-nativeimage" --build-arg FROM=ghcr.io/graalvm/graalvm-ce:java11-21.1.0 .
 
 # RPM Build
 docker build -t $REGISTRY/rpmbuild:centos7 -f "$DOCKER_BUILDERS_DIR/Dockerfile-rpmbuild" --build-arg FROM=centos:7 .
@@ -32,8 +32,8 @@ docker build -t $REGISTRY/rpmbuild:fedora34 -f "$DOCKER_BUILDERS_DIR/Dockerfile-
 echo "${BINTRAY_API_KEY}" | docker login --username "${BINTRAY_USERNAME}" --password-stdin $REGISTRY
 
 # Push All Builders to Remote Registry
-docker push $REGISTRY/nativeimage:graalvm-ce-21.0.0-java8
-docker push $REGISTRY/nativeimage:graalvm-ce-21.0.0-java11
+docker push $REGISTRY/nativeimage:graalvm-ce-21.1.0-java8
+docker push $REGISTRY/nativeimage:graalvm-ce-21.1.0-java11
 docker push $REGISTRY/rpmbuild:centos7
 docker push $REGISTRY/rpmbuild:centos8
 docker push $REGISTRY/rpmbuild:fedora32
@@ -41,8 +41,8 @@ docker push $REGISTRY/rpmbuild:fedora33
 docker push $REGISTRY/rpmbuild:fedora34
 
 # Publish Images on Bintray
-curl -sfLS -X POST -u "${BINTRAY_USERNAME}:${BINTRAY_API_KEY}" $BINTRAY_API_URL/content/$BINTRAY_ORG/$BINTRAY_REPO/nativeimage/graalvm-ce-21.0.0-java8/publish
-curl -sfLS -X POST -u "${BINTRAY_USERNAME}:${BINTRAY_API_KEY}" $BINTRAY_API_URL/content/$BINTRAY_ORG/$BINTRAY_REPO/nativeimage/graalvm-ce-21.0.0-java11/publish
+curl -sfLS -X POST -u "${BINTRAY_USERNAME}:${BINTRAY_API_KEY}" $BINTRAY_API_URL/content/$BINTRAY_ORG/$BINTRAY_REPO/nativeimage/graalvm-ce-21.1.0-java8/publish
+curl -sfLS -X POST -u "${BINTRAY_USERNAME}:${BINTRAY_API_KEY}" $BINTRAY_API_URL/content/$BINTRAY_ORG/$BINTRAY_REPO/nativeimage/graalvm-ce-21.1.0-java11/publish
 curl -sfLS -X POST -u "${BINTRAY_USERNAME}:${BINTRAY_API_KEY}" $BINTRAY_API_URL/content/$BINTRAY_ORG/$BINTRAY_REPO/rpmbuild/centos8/publish
 curl -sfLS -X POST -u "${BINTRAY_USERNAME}:${BINTRAY_API_KEY}" $BINTRAY_API_URL/content/$BINTRAY_ORG/$BINTRAY_REPO/rpmbuild/fedora32/publish
 curl -sfLS -X POST -u "${BINTRAY_USERNAME}:${BINTRAY_API_KEY}" $BINTRAY_API_URL/content/$BINTRAY_ORG/$BINTRAY_REPO/rpmbuild/fedora33/publish

--- a/distributions/scripts/build-and-push-docker-builders-to-bintray.sh
+++ b/distributions/scripts/build-and-push-docker-builders-to-bintray.sh
@@ -18,8 +18,8 @@ BINTRAY_REPO="builders"
 REGISTRY="optum-docker-builders.bintray.io"
 
 # Native Image
-docker build -t $REGISTRY/nativeimage:graalvm-ce-21.0.0-java8 -f "$DOCKER_BUILDERS_DIR/Dockerfile-nativeimage" --build-arg FROM=oracle/graalvm-ce:21.0.0-java8 .
-docker build -t $REGISTRY/nativeimage:graalvm-ce-21.0.0-java11 -f "$DOCKER_BUILDERS_DIR/Dockerfile-nativeimage" --build-arg FROM=oracle/graalvm-ce:21.0.0-java11 .
+docker build -t $REGISTRY/nativeimage:graalvm-ce-21.0.0-java8 -f "$DOCKER_BUILDERS_DIR/Dockerfile-nativeimage" --build-arg FROM=ghcr.io/graalvm/graalvm-ce:21.0.0-java8 .
+docker build -t $REGISTRY/nativeimage:graalvm-ce-21.0.0-java11 -f "$DOCKER_BUILDERS_DIR/Dockerfile-nativeimage" --build-arg FROM=ghcr.io/graalvm/graalvm-ce:21.0.0-java11 .
 
 # RPM Build
 docker build -t $REGISTRY/rpmbuild:centos7 -f "$DOCKER_BUILDERS_DIR/Dockerfile-rpmbuild" --build-arg FROM=centos:7 .

--- a/distributions/scripts/build-and-push-docker-builders-to-bintray.sh
+++ b/distributions/scripts/build-and-push-docker-builders-to-bintray.sh
@@ -18,8 +18,8 @@ BINTRAY_REPO="builders"
 REGISTRY="optum-docker-builders.bintray.io"
 
 # Native Image
-docker build -t $REGISTRY/nativeimage:graalvm-ce-20.3.0-java8 -f "$DOCKER_BUILDERS_DIR/Dockerfile-nativeimage" --build-arg FROM=oracle/graalvm-ce:20.3.0-java8 .
-docker build -t $REGISTRY/nativeimage:graalvm-ce-20.3.0-java11 -f "$DOCKER_BUILDERS_DIR/Dockerfile-nativeimage" --build-arg FROM=oracle/graalvm-ce:20.3.0-java11 .
+docker build -t $REGISTRY/nativeimage:graalvm-ce-21.0.0-java8 -f "$DOCKER_BUILDERS_DIR/Dockerfile-nativeimage" --build-arg FROM=oracle/graalvm-ce:21.0.0-java8 .
+docker build -t $REGISTRY/nativeimage:graalvm-ce-21.0.0-java11 -f "$DOCKER_BUILDERS_DIR/Dockerfile-nativeimage" --build-arg FROM=oracle/graalvm-ce:21.0.0-java11 .
 
 # RPM Build
 docker build -t $REGISTRY/rpmbuild:centos7 -f "$DOCKER_BUILDERS_DIR/Dockerfile-rpmbuild" --build-arg FROM=centos:7 .
@@ -32,8 +32,8 @@ docker build -t $REGISTRY/rpmbuild:fedora34 -f "$DOCKER_BUILDERS_DIR/Dockerfile-
 echo "${BINTRAY_API_KEY}" | docker login --username "${BINTRAY_USERNAME}" --password-stdin $REGISTRY
 
 # Push All Builders to Remote Registry
-docker push $REGISTRY/nativeimage:graalvm-ce-20.3.0-java8
-docker push $REGISTRY/nativeimage:graalvm-ce-20.3.0-java11
+docker push $REGISTRY/nativeimage:graalvm-ce-21.0.0-java8
+docker push $REGISTRY/nativeimage:graalvm-ce-21.0.0-java11
 docker push $REGISTRY/rpmbuild:centos7
 docker push $REGISTRY/rpmbuild:centos8
 docker push $REGISTRY/rpmbuild:fedora32
@@ -41,8 +41,8 @@ docker push $REGISTRY/rpmbuild:fedora33
 docker push $REGISTRY/rpmbuild:fedora34
 
 # Publish Images on Bintray
-curl -sfLS -X POST -u "${BINTRAY_USERNAME}:${BINTRAY_API_KEY}" $BINTRAY_API_URL/content/$BINTRAY_ORG/$BINTRAY_REPO/nativeimage/graalvm-ce-20.3.0-java8/publish
-curl -sfLS -X POST -u "${BINTRAY_USERNAME}:${BINTRAY_API_KEY}" $BINTRAY_API_URL/content/$BINTRAY_ORG/$BINTRAY_REPO/nativeimage/graalvm-ce-20.3.0-java11/publish
+curl -sfLS -X POST -u "${BINTRAY_USERNAME}:${BINTRAY_API_KEY}" $BINTRAY_API_URL/content/$BINTRAY_ORG/$BINTRAY_REPO/nativeimage/graalvm-ce-21.0.0-java8/publish
+curl -sfLS -X POST -u "${BINTRAY_USERNAME}:${BINTRAY_API_KEY}" $BINTRAY_API_URL/content/$BINTRAY_ORG/$BINTRAY_REPO/nativeimage/graalvm-ce-21.0.0-java11/publish
 curl -sfLS -X POST -u "${BINTRAY_USERNAME}:${BINTRAY_API_KEY}" $BINTRAY_API_URL/content/$BINTRAY_ORG/$BINTRAY_REPO/rpmbuild/centos8/publish
 curl -sfLS -X POST -u "${BINTRAY_USERNAME}:${BINTRAY_API_KEY}" $BINTRAY_API_URL/content/$BINTRAY_ORG/$BINTRAY_REPO/rpmbuild/fedora32/publish
 curl -sfLS -X POST -u "${BINTRAY_USERNAME}:${BINTRAY_API_KEY}" $BINTRAY_API_URL/content/$BINTRAY_ORG/$BINTRAY_REPO/rpmbuild/fedora33/publish

--- a/distributions/scripts/build-and-push-docker-builders-to-bintray.sh
+++ b/distributions/scripts/build-and-push-docker-builders-to-bintray.sh
@@ -18,8 +18,8 @@ BINTRAY_REPO="builders"
 REGISTRY="optum-docker-builders.bintray.io"
 
 # Native Image
-docker build -t $REGISTRY/nativeimage:graalvm-ce-21.0.0-java8 -f "$DOCKER_BUILDERS_DIR/Dockerfile-nativeimage" --build-arg FROM=ghcr.io/graalvm/graalvm-ce:21.0.0-java8 .
-docker build -t $REGISTRY/nativeimage:graalvm-ce-21.0.0-java11 -f "$DOCKER_BUILDERS_DIR/Dockerfile-nativeimage" --build-arg FROM=ghcr.io/graalvm/graalvm-ce:21.0.0-java11 .
+docker build -t $REGISTRY/nativeimage:graalvm-ce-21.0.0-java8 -f "$DOCKER_BUILDERS_DIR/Dockerfile-nativeimage" --build-arg FROM=ghcr.io/graalvm/graalvm-ce:java8-21.0.0 .
+docker build -t $REGISTRY/nativeimage:graalvm-ce-21.0.0-java11 -f "$DOCKER_BUILDERS_DIR/Dockerfile-nativeimage" --build-arg FROM=ghcr.io/graalvm/graalvm-ce:java11-21.0.0 .
 
 # RPM Build
 docker build -t $REGISTRY/rpmbuild:centos7 -f "$DOCKER_BUILDERS_DIR/Dockerfile-rpmbuild" --build-arg FROM=centos:7 .

--- a/distributions/scripts/build-and-push-docker-builders.sh
+++ b/distributions/scripts/build-and-push-docker-builders.sh
@@ -15,7 +15,7 @@ DOCKER_BUILDERS_DIR="$ROOT_DIR/distributions/docker-builders"
 BINTRAY_API_URL="https://api.bintray.com"
 BINTRAY_ORG="optum"
 BINTRAY_REPO="builders"
-REGISTRY="optum-docker-builders.bintray.io"
+REGISTRY="ghcr.io"
 
 # Native Image
 docker build -t $REGISTRY/nativeimage:graalvm-ce-21.1.0-java8 -f "$DOCKER_BUILDERS_DIR/Dockerfile-nativeimage" --build-arg FROM=ghcr.io/graalvm/graalvm-ce:java8-21.1.0 .


### PR DESCRIPTION
Release Notes: https://github.com/graalvm/graalvm-ce-builds/releases/tag/vm-21.0.0

Updated the docker image references to pull from Github Container registry (moved by Oracle)

Depends on #51 