### PR TITLE
Dependency Cleanup

### DIFF
--- a/attribution.txt
+++ b/attribution.txt
@@ -839,28 +839,6 @@ THE SOFTWARE.
 
 -------------------------------------------------------------------------------------------------------------------------------
 
-Package: org.ow2.asm:asm:5.0.4
-
-License: BSD-3-Clause
-
-Copyrights: 
-
-
-License Text: 
-Copyright (c) <year> <owner> . All rights reserved.
-
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-
-   1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-
-   2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-
-   3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
--------------------------------------------------------------------------------------------------------------------------------
-
 Package: org.opentest4j:opentest4j:1.2.0
 
 License: Apache-2.0

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -369,7 +369,6 @@
                                         <include>com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:*:*</include>
                                         <include>org.apache.maven:maven-model:*:*:*</include>
                                         <include>org.codehaus.plexus:plexus-utils:*:*:*</include>
-                                        <include>org.ow2.asm:asm:*:*:*</include>
                                         <include>org.slf4j:slf4j-api:*:*:*</include>
                                         <include>org.slf4j:slf4j-nop:*:*:*</include>
                                         <include>org.yaml:snakeyaml:*:*:*</include>

--- a/cli/src/test/groovy/com/optum/sourcehawk/cli/FixCommandSpec.groovy
+++ b/cli/src/test/groovy/com/optum/sourcehawk/cli/FixCommandSpec.groovy
@@ -93,7 +93,6 @@ class FixCommandSpec extends CliBaseSpecification {
         then:
         properties.getProperty("config.stopBubbling") == "true"
         properties.getProperty("lombok.addLombokGeneratedAnnotation") == "true"
-        properties.getProperty("lombok.anyConstructor.addConstructorProperties") == "true"
     }
 
     def "main: no files updated"() {

--- a/cli/src/test/resources/flattened/sourcehawk-flattened-base.yml
+++ b/cli/src/test/resources/flattened/sourcehawk-flattened-base.yml
@@ -23,7 +23,7 @@ file-protocols:
     property-name: "config.stopBubbling"
     expected-property-value: true
   - enforcer: ".common.StringPropertyEquals"
-    property-name: "lombok.anyConstructor.addConstructorProperties"
+    property-name: "lombok.addLombokGeneratedAnnotation"
     expected-property-value: true
 - name: "Notice"
   description: null

--- a/cli/src/test/resources/flattened/sourcehawk-flattened-override.yml
+++ b/cli/src/test/resources/flattened/sourcehawk-flattened-override.yml
@@ -35,8 +35,8 @@ file-protocols:
     property-name: "config.stopBubbling"
     expected-property-value: false
   - enforcer: ".common.StringPropertyEquals"
-    property-name: "lombok.anyConstructor.addConstructorProperties"
-    expected-property-value: false
+    property-name: "lombok.addLombokGeneratedAnnotation"
+    expected-property-value: true
 - name: "Notice"
   description: null
   repository-path: "NOTICE.txt"

--- a/cli/src/test/resources/repo-updates/lombok.config
+++ b/cli/src/test/resources/repo-updates/lombok.config
@@ -4,6 +4,3 @@ config.stopBubbling = false
 
 # This allows us to notify Jacoco static code analysis to skip scanning generated code
 lombok.addLombokGeneratedAnnotation = false
-
-# Constructor properties are useful for deserialization of objects with Jackson
-lombok.anyConstructor.addConstructorProperties = false

--- a/cli/src/test/resources/repo-updates/sourcehawk.yml
+++ b/cli/src/test/resources/repo-updates/sourcehawk.yml
@@ -15,6 +15,3 @@ file-protocols:
       - enforcer: .common.StringPropertyEquals
         property-name: lombok.addLombokGeneratedAnnotation
         expected-property-value: true
-      - enforcer: .common.StringPropertyEquals
-        property-name: lombok.anyConstructor.addConstructorProperties
-        expected-property-value: true

--- a/cli/src/test/resources/repo/lombok.config
+++ b/cli/src/test/resources/repo/lombok.config
@@ -4,6 +4,3 @@ config.stopBubbling = true
 
 # This allows us to notify Jacoco static code analysis to skip scanning generated code
 lombok.addLombokGeneratedAnnotation = true
-
-# Constructor properties are useful for deserialization of objects with Jackson
-lombok.anyConstructor.addConstructorProperties = true

--- a/cli/src/test/resources/repo/sourcehawk.yml
+++ b/cli/src/test/resources/repo/sourcehawk.yml
@@ -15,6 +15,3 @@ file-protocols:
       - enforcer: .common.StringPropertyEquals
         property-name: lombok.addLombokGeneratedAnnotation
         expected-property-value: true
-      - enforcer: .common.StringPropertyEquals
-        property-name: lombok.anyConstructor.addConstructorProperties
-        expected-property-value: true

--- a/cli/src/test/resources/sourcehawk-override.yml
+++ b/cli/src/test/resources/sourcehawk-override.yml
@@ -34,8 +34,9 @@ file-protocols:
         property-name: config.stopBubbling
         expected-property-value: false
       - enforcer: .common.StringPropertyEquals
-        property-name: lombok.anyConstructor.addConstructorProperties
-        expected-property-value: false
+        property-name: lombok.addLombokGeneratedAnnotation
+        expected-property-value: true
+
 
 # Composable recursive source hawk configs (Must be public repo)
 config-locations:

--- a/enforcer/file/pom.xml
+++ b/enforcer/file/pom.xml
@@ -41,7 +41,6 @@
                                         <include>com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:*:*:*</include>
                                         <include>org.apache.maven:maven-model:*:*:*</include>
                                         <include>org.codehaus.plexus:plexus-utils:*:*:*</include>
-                                        <include>org.ow2.asm:asm:*:*:*</include>
                                         <include>org.slf4j:slf4j-api:*:*:*</include>
                                         <include>org.yaml:snakeyaml:*:*:*</include>
                                     </includes>

--- a/exec/pom.xml
+++ b/exec/pom.xml
@@ -95,7 +95,6 @@
                                         <include>com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:*:*</include>
                                         <include>org.apache.maven:maven-model:*:*:*</include>
                                         <include>org.codehaus.plexus:plexus-utils:*:*:*</include>
-                                        <include>org.ow2.asm:asm:*:*:*</include>
                                         <include>org.slf4j:slf4j-api:*:*:*</include>
                                         <include>org.slf4j:slf4j-nop:*:*:*</include>
                                         <include>org.yaml:snakeyaml:*:*:*</include>

--- a/exec/src/test/resources/sourcehawk-flattened-base.yml
+++ b/exec/src/test/resources/sourcehawk-flattened-base.yml
@@ -23,7 +23,7 @@ file-protocols:
     property-name: "config.stopBubbling"
     expected-property-value: true
   - enforcer: ".common.StringPropertyEquals"
-    property-name: "lombok.anyConstructor.addConstructorProperties"
+    property-name: "lombok.addLombokGeneratedAnnotation"
     expected-property-value: true
 - name: "Notice"
   description: null

--- a/pom.xml
+++ b/pom.xml
@@ -180,7 +180,6 @@
                                         <includes>
                                             <include>com.fasterxml.jackson.core:*:*:*:*</include>
                                             <include>com.optum.sourcehawk:*:*:*:*</include>
-                                            <include>javax.activation:activation</include>
                                             <include>*:*:*:*:provided</include>
                                             <include>*:*:*:*:test</include>
                                         </includes>


### PR DESCRIPTION
Remove `javax.activation` and `asm` from enforcer restriction overrides
Fix tests broken by config update in parent